### PR TITLE
Use process.cwd() instead of pwd to support multiple systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple mock server that can be used in front end development. Instead of creating json files you can just publish TypeScript objects as json",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "example": "ts-node-dev src/index.ts --path=$(pwd)/tms-models --port=5000",
+    "example": "ts-node-dev src/index.ts --path=tms-models --port=5000",
     "start": "ts-node-dev src/index.ts"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const app: Express = express();
 
 const { path, port } = argv;
 
-const basePath = `${path}`;
+const basePath = `${process.cwd()}/${path}`;
 
 interface RegisteredEndpoint {
   httpVerb: string;


### PR DESCRIPTION
Use process.cwd() instead of pwd to define root dir to support Windows and Unix systems